### PR TITLE
Goサーバーを起動し、ブラウザからアクセスできるようにした

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -2,3 +2,7 @@ FROM golang:1.15
 
 WORKDIR /go/src/go-sample
 COPY . .
+
+EXPOSE 8080
+
+CMD [ "go", "run", "main.go" ]

--- a/api/main.go
+++ b/api/main.go
@@ -1,7 +1,19 @@
 package main
 
-import "fmt"
+import (
+	"fmt"
+	"log"
+	"net/http"
+)
+
+func hello(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	w.Header().Set("Content-Type", "application/json")
+	w.Write([]byte(`{"message":"Hello World!"}`))
+}
 
 func main() {
-	fmt.Println("Hello, World!")
+	http.HandleFunc("/", hello)
+	fmt.Println("Server started.")
+	log.Fatal(http.ListenAndServe(":8080", nil))
 }

--- a/api/main.go
+++ b/api/main.go
@@ -12,8 +12,12 @@ func hello(w http.ResponseWriter, r *http.Request) {
 	w.Write([]byte(`{"message":"Hello World!"}`))
 }
 
-func main() {
+func handleRequests() {
 	http.HandleFunc("/", hello)
-	fmt.Println("Server started.")
 	log.Fatal(http.ListenAndServe(":8080", nil))
+}
+
+func main() {
+	fmt.Println("Server started.")
+	handleRequests()
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,8 @@ version: '3'
 services: 
   api:
     build: ./api
+    ports:
+      - "8080:8080"
     tty: true
     volumes:
       - ./api:/go/src/go-sample


### PR DESCRIPTION
## 変更点

goのコンテナ単独で実行する場合には、`docker build -t api PATH_TO_CONTAINER`でビルドし、`docker run -it -p api 8080:8080`で実行できる。
docker-composeで実行する場合は、`docker-compose build`でビルドし、`docker-compose up`で実行できる。

- http://localhost:8080/ にて`{"message":"Hello World!"}`を表示
- Dockerfile
  - `EXPOSE`でポート8080を開放
  - 実行時のデフォルトのコマンドで`main.go`を実行
- docker-compose
  - `ports: - "HOST:CONTAINER"`を設定

## リンク

- [A RESTFul Go living in docker](https://levelup.gitconnected.com/a-restful-go-living-in-docker-14f06fdedd28)
- [DockerとGoで簡単にapiサーバーを立ててみる](https://qiita.com/rin1208/items/56abb60acc54ad5f1e33#dockerfile)
- [Creating a RESTful API With Golang](https://tutorialedge.net/golang/creating-restful-api-with-golang/)