### PR TITLE
デモデータでRESTfulな記事機能を実装

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -1,0 +1,5 @@
+module go-sample
+
+go 1.15
+
+require github.com/gorilla/mux v1.8.0 // indirect

--- a/api/go.mod
+++ b/api/go.mod
@@ -2,4 +2,4 @@ module go-sample
 
 go 1.15
 
-require github.com/gorilla/mux v1.8.0 // indirect
+require github.com/gorilla/mux v1.8.0

--- a/api/go.sum
+++ b/api/go.sum
@@ -1,0 +1,2 @@
+github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
+github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=

--- a/api/main.go
+++ b/api/main.go
@@ -3,87 +3,11 @@ package main
 import (
 	"fmt"
 	"log"
-	"strconv"
 	"net/http"
-	"encoding/json"
 	"github.com/gorilla/mux"
+
+	"go-sample/pkg/articles"
 )
-
-type Article struct {
-	Id int `json:"id"`
-	Title	string `json:"title"`
-	Desc string `json:"desc"`
-	Content string `json:"content"`
-}
-
-var Articles []Article
-
-func createDemoArticles() {
-	Articles = []Article{
-		Article{Id: 1, Title: "Test Article", Desc: "Article Description", Content: "Test Content"},
-		Article{Id: 2, Title: "Test Article 2", Desc: "Article Description 2", Content: "Test Content 2"},
-	}
-}
-
-func returnArticles(w http.ResponseWriter, r *http.Request) {
-	json.NewEncoder(w).Encode(Articles)
-}
-
-func returnArticle(w http.ResponseWriter, r *http.Request) {
-	vars := mux.Vars(r)
-	key, err := strconv.Atoi(vars["id"])
-	if err != nil {
-		http.Error(w, "Invalid Article Id", http.StatusBadRequest)
-	}
-
-	for _, article := range Articles {
-		if article.Id == key {
-			json.NewEncoder(w).Encode(article)
-		}
-	}
-}
-
-func createArticle(w http.ResponseWriter, r *http.Request) {
-	var article Article
-
-	json.NewDecoder(r.Body).Decode(&article)
-	Articles = append(Articles, article)
-
-	json.NewEncoder(w).Encode(article)
-}
-
-func updateArticle(w http.ResponseWriter, r *http.Request) {
-	vars := mux.Vars(r)
-	key, err := strconv.Atoi(vars["id"])
-	if err != nil {
-		http.Error(w, "Invalid Article Id", http.StatusBadRequest)
-	}
-
-	var updateArticle Article
-	json.NewDecoder(r.Body).Decode(&updateArticle)
-
-	for index, article := range Articles {
-		if article.Id == key {
-			Articles[index] = updateArticle
-			json.NewEncoder(w).Encode(updateArticle)
-		}
-	}
-}
-
-func deleteArticle(w http.ResponseWriter, r *http.Request) {
-	vars := mux.Vars(r)
-	key, err := strconv.Atoi(vars["id"])
-	if err != nil {
-		http.Error(w, "Invalid Article Id", http.StatusBadRequest)
-	}
-
-	for index, article := range Articles {
-		if article.Id == key {
-			Articles = append(Articles[:index], Articles[index+1:]...)
-			w.WriteHeader(http.StatusNoContent)
-		}
-	}
-}
 
 func hello(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
@@ -94,16 +18,15 @@ func hello(w http.ResponseWriter, r *http.Request) {
 func handleRequests() {
 	r := mux.NewRouter().StrictSlash(true)
 	r.HandleFunc("/", hello)
-	r.HandleFunc("/articles", createArticle).Methods("POST")
-	r.HandleFunc("/articles", returnArticles)
-	r.HandleFunc("/articles/{id}", updateArticle).Methods("PUT")
-	r.HandleFunc("/articles/{id}", deleteArticle).Methods("DELETE")
-	r.HandleFunc("/articles/{id}", returnArticle)
+	r.HandleFunc("/articles", articles.CreateArticle).Methods("POST")
+	r.HandleFunc("/articles", articles.ReturnArticles)
+	r.HandleFunc("/articles/{id}", articles.UpdateArticle).Methods("PUT")
+	r.HandleFunc("/articles/{id}", articles.DeleteArticle).Methods("DELETE")
+	r.HandleFunc("/articles/{id}", articles.ReturnArticle)
 	log.Fatal(http.ListenAndServe(":8080", r))
 }
 
 func main() {
 	fmt.Println("Rest API v1.8 - Mux Routers")
-	createDemoArticles()
 	handleRequests()
 }

--- a/api/main.go
+++ b/api/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"log"
+	"strconv"
 	"net/http"
 	"encoding/json"
 	"github.com/gorilla/mux"
@@ -28,6 +29,20 @@ func returnArticles(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(Articles)
 }
 
+func returnArticle(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	key, err := strconv.Atoi(vars["id"])
+	if err != nil {
+		http.Error(w, "Invalid Article Id", http.StatusBadRequest)
+	}
+
+	for _, article := range Articles {
+		if article.Id == key {
+			json.NewEncoder(w).Encode(article)
+		}
+	}
+}
+
 func hello(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 	w.Header().Set("Content-Type", "application/json")
@@ -38,6 +53,7 @@ func handleRequests() {
 	r := mux.NewRouter().StrictSlash(true)
 	r.HandleFunc("/", hello)
 	r.HandleFunc("/articles", returnArticles)
+	r.HandleFunc("/articles/{id}", returnArticle)
 	log.Fatal(http.ListenAndServe(":8080", r))
 }
 

--- a/api/main.go
+++ b/api/main.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"net/http"
 	"encoding/json"
+	"github.com/gorilla/mux"
 )
 
 type Article struct {
@@ -34,13 +35,14 @@ func hello(w http.ResponseWriter, r *http.Request) {
 }
 
 func handleRequests() {
-	http.HandleFunc("/", hello)
-	http.HandleFunc("/articles", returnArticles)
-	log.Fatal(http.ListenAndServe(":8080", nil))
+	r := mux.NewRouter().StrictSlash(true)
+	r.HandleFunc("/", hello)
+	r.HandleFunc("/articles", returnArticles)
+	log.Fatal(http.ListenAndServe(":8080", r))
 }
 
 func main() {
-	fmt.Println("Server started.")
+	fmt.Println("Rest API v1.8 - Mux Routers")
 	createDemoArticles()
 	handleRequests()
 }

--- a/api/main.go
+++ b/api/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+
 	"github.com/gorilla/mux"
 
 	"go-sample/pkg/articles"

--- a/api/main.go
+++ b/api/main.go
@@ -11,7 +11,7 @@ type Article struct {
 	Id int `json:"id"`
 	Title	string `json:"title"`
 	Desc string `json:"desc"`
-	Content string `json:content`
+	Content string `json:"content"`
 }
 
 var Articles []Article

--- a/api/main.go
+++ b/api/main.go
@@ -52,6 +52,24 @@ func createArticle(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(article)
 }
 
+func updateArticle(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	key, err := strconv.Atoi(vars["id"])
+	if err != nil {
+		http.Error(w, "Invalid Article Id", http.StatusBadRequest)
+	}
+
+	var updateArticle Article
+	json.NewDecoder(r.Body).Decode(&updateArticle)
+
+	for index, article := range Articles {
+		if article.Id == key {
+			Articles[index] = updateArticle
+			json.NewEncoder(w).Encode(updateArticle)
+		}
+	}
+}
+
 func deleteArticle(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	key, err := strconv.Atoi(vars["id"])
@@ -78,6 +96,7 @@ func handleRequests() {
 	r.HandleFunc("/", hello)
 	r.HandleFunc("/articles", createArticle).Methods("POST")
 	r.HandleFunc("/articles", returnArticles)
+	r.HandleFunc("/articles/{id}", updateArticle).Methods("PUT")
 	r.HandleFunc("/articles/{id}", deleteArticle).Methods("DELETE")
 	r.HandleFunc("/articles/{id}", returnArticle)
 	log.Fatal(http.ListenAndServe(":8080", r))

--- a/api/main.go
+++ b/api/main.go
@@ -4,7 +4,28 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"encoding/json"
 )
+
+type Article struct {
+	Id int `json:"id"`
+	Title	string `json:"title"`
+	Desc string `json:"desc"`
+	Content string `json:content`
+}
+
+var Articles []Article
+
+func createDemoArticles() {
+	Articles = []Article{
+		Article{Id: 1, Title: "Test Article", Desc: "Article Description", Content: "Test Content"},
+		Article{Id: 2, Title: "Test Article 2", Desc: "Article Description 2", Content: "Test Content 2"},
+	}
+}
+
+func returnArticles(w http.ResponseWriter, r *http.Request) {
+	json.NewEncoder(w).Encode(Articles)
+}
 
 func hello(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
@@ -14,10 +35,12 @@ func hello(w http.ResponseWriter, r *http.Request) {
 
 func handleRequests() {
 	http.HandleFunc("/", hello)
+	http.HandleFunc("/articles", returnArticles)
 	log.Fatal(http.ListenAndServe(":8080", nil))
 }
 
 func main() {
 	fmt.Println("Server started.")
+	createDemoArticles()
 	handleRequests()
 }

--- a/api/main.go
+++ b/api/main.go
@@ -43,6 +43,15 @@ func returnArticle(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+func createArticle(w http.ResponseWriter, r *http.Request) {
+	var article Article
+
+	json.NewDecoder(r.Body).Decode(&article)
+	Articles = append(Articles, article)
+
+	json.NewEncoder(w).Encode(article)
+}
+
 func hello(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 	w.Header().Set("Content-Type", "application/json")
@@ -52,6 +61,7 @@ func hello(w http.ResponseWriter, r *http.Request) {
 func handleRequests() {
 	r := mux.NewRouter().StrictSlash(true)
 	r.HandleFunc("/", hello)
+	r.HandleFunc("/articles", createArticle).Methods("POST")
 	r.HandleFunc("/articles", returnArticles)
 	r.HandleFunc("/articles/{id}", returnArticle)
 	log.Fatal(http.ListenAndServe(":8080", r))

--- a/api/main.go
+++ b/api/main.go
@@ -52,6 +52,21 @@ func createArticle(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(article)
 }
 
+func deleteArticle(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	key, err := strconv.Atoi(vars["id"])
+	if err != nil {
+		http.Error(w, "Invalid Article Id", http.StatusBadRequest)
+	}
+
+	for index, article := range Articles {
+		if article.Id == key {
+			Articles = append(Articles[:index], Articles[index+1:]...)
+			w.WriteHeader(http.StatusNoContent)
+		}
+	}
+}
+
 func hello(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 	w.Header().Set("Content-Type", "application/json")
@@ -63,6 +78,7 @@ func handleRequests() {
 	r.HandleFunc("/", hello)
 	r.HandleFunc("/articles", createArticle).Methods("POST")
 	r.HandleFunc("/articles", returnArticles)
+	r.HandleFunc("/articles/{id}", deleteArticle).Methods("DELETE")
 	r.HandleFunc("/articles/{id}", returnArticle)
 	log.Fatal(http.ListenAndServe(":8080", r))
 }

--- a/api/pkg/articles/articles.go
+++ b/api/pkg/articles/articles.go
@@ -1,16 +1,17 @@
 package articles
 
 import (
-	"strconv"
-	"net/http"
 	"encoding/json"
+	"net/http"
+	"strconv"
+
 	"github.com/gorilla/mux"
 )
 
 type Article struct {
-	Id int `json:"id"`
-	Title	string `json:"title"`
-	Desc string `json:"desc"`
+	Id      int    `json:"id"`
+	Title   string `json:"title"`
+	Desc    string `json:"desc"`
 	Content string `json:"content"`
 }
 

--- a/api/pkg/articles/articles.go
+++ b/api/pkg/articles/articles.go
@@ -1,0 +1,88 @@
+package articles
+
+import (
+	"strconv"
+	"net/http"
+	"encoding/json"
+	"github.com/gorilla/mux"
+)
+
+type Article struct {
+	Id int `json:"id"`
+	Title	string `json:"title"`
+	Desc string `json:"desc"`
+	Content string `json:"content"`
+}
+
+var Articles []Article
+
+func init() {
+	createDemoArticles()
+}
+
+func createDemoArticles() {
+	Articles = []Article{
+		Article{Id: 1, Title: "Test Article", Desc: "Article Description", Content: "Test Content"},
+		Article{Id: 2, Title: "Test Article 2", Desc: "Article Description 2", Content: "Test Content 2"},
+	}
+}
+
+func ReturnArticles(w http.ResponseWriter, r *http.Request) {
+	json.NewEncoder(w).Encode(Articles)
+}
+
+func ReturnArticle(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	key, err := strconv.Atoi(vars["id"])
+	if err != nil {
+		http.Error(w, "Invalid Article Id", http.StatusBadRequest)
+	}
+
+	for _, article := range Articles {
+		if article.Id == key {
+			json.NewEncoder(w).Encode(article)
+		}
+	}
+}
+
+func CreateArticle(w http.ResponseWriter, r *http.Request) {
+	var article Article
+
+	json.NewDecoder(r.Body).Decode(&article)
+	Articles = append(Articles, article)
+
+	json.NewEncoder(w).Encode(article)
+}
+
+func UpdateArticle(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	key, err := strconv.Atoi(vars["id"])
+	if err != nil {
+		http.Error(w, "Invalid Article Id", http.StatusBadRequest)
+	}
+
+	var updateArticle Article
+	json.NewDecoder(r.Body).Decode(&updateArticle)
+
+	for index, article := range Articles {
+		if article.Id == key {
+			Articles[index] = updateArticle
+			json.NewEncoder(w).Encode(updateArticle)
+		}
+	}
+}
+
+func DeleteArticle(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	key, err := strconv.Atoi(vars["id"])
+	if err != nil {
+		http.Error(w, "Invalid Article Id", http.StatusBadRequest)
+	}
+
+	for index, article := range Articles {
+		if article.Id == key {
+			Articles = append(Articles[:index], Articles[index+1:]...)
+			w.WriteHeader(http.StatusNoContent)
+		}
+	}
+}

--- a/api/pkg/articles/articles.go
+++ b/api/pkg/articles/articles.go
@@ -28,6 +28,7 @@ func createDemoArticles() {
 }
 
 func ReturnArticles(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(Articles)
 }
 
@@ -40,6 +41,7 @@ func ReturnArticle(w http.ResponseWriter, r *http.Request) {
 
 	for _, article := range Articles {
 		if article.Id == key {
+			w.Header().Set("Content-Type", "application/json")
 			json.NewEncoder(w).Encode(article)
 		}
 	}
@@ -51,6 +53,7 @@ func CreateArticle(w http.ResponseWriter, r *http.Request) {
 	json.NewDecoder(r.Body).Decode(&article)
 	Articles = append(Articles, article)
 
+	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(article)
 }
 
@@ -67,6 +70,7 @@ func UpdateArticle(w http.ResponseWriter, r *http.Request) {
 	for index, article := range Articles {
 		if article.Id == key {
 			Articles[index] = updateArticle
+			w.Header().Set("Content-Type", "application/json")
 			json.NewEncoder(w).Encode(updateArticle)
 		}
 	}
@@ -82,6 +86,7 @@ func DeleteArticle(w http.ResponseWriter, r *http.Request) {
 	for index, article := range Articles {
 		if article.Id == key {
 			Articles = append(Articles[:index], Articles[index+1:]...)
+			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusNoContent)
 		}
 	}


### PR DESCRIPTION
## 変更点

- go.modを追加
- gorilla/mux ルーターを追加
- Article(記事)のCRUD機能を追加
  - 全体/単体表示
  - 新規作成
  - 既存更新(置換)
  - 削除
- 機能のファイル切り出し

※DBは未使用であり、モックデータを定義している

## リンク
- [Creating a RESTful API With Golang](https://tutorialedge.net/golang/creating-restful-api-with-golang/#our-articles-structure)
- https://github.com/golang-standards/project-layout