### PR TITLE
Goモジュール名をGithubリポジトリからのパスに変更

### DIFF
--- a/cmd/go-sample/main.go
+++ b/cmd/go-sample/main.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/gorilla/mux"
 
-	"go-sample/pkg/articles"
+	"github.com/daikideal/go-sample/pkg/articles"
 )
 
 func hello(w http.ResponseWriter, r *http.Request) {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module go-sample
+module github.com/daikideal/go-sample
 
 go 1.15
 


### PR DESCRIPTION
## 変更点

Goプロジェクトの慣習に倣った。
このコードはGithubで管理されるので、モジュール名はリモートリポジトリのpathになる。

## リンク
- #8 
- [Go Modules Reference#go mod edit](https://golang.org/ref/mod#go-mod-edit)